### PR TITLE
chore: remove 'default' from list of available themes

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -51,7 +51,7 @@ config.app_config.APP_HEADER_DEFAULTS.title = "تطبيق دايم";
 config.app_config.APP_LANGUAGES_META = { kw_ar: { rtl: true } }
 config.app_config.NOTIFICATION_DEFAULTS.title = "New message from Dayem App";
 config.app_config.NOTIFICATION_DEFAULTS.text = "You have a new message from Dayem App";
-config.app_config.APP_THEMES.available = ["plh_kids_kw", "default"];
+config.app_config.APP_THEMES.available = ["plh_kids_kw"];
 config.app_config.APP_THEMES.defaultThemeName = "plh_kids_kw";
 
 export default config;


### PR DESCRIPTION
Minor change to deployment config to remove support for the `default` theme. 

This change should only affect developers and authors: previously, as a developer working on multiple deployments, it was possible to switch to the `plh_kids_kw` deployment and still have the `default` theme active, which isn't supported by this deployment. This change will enforce setting the active theme to `plh_kids_kw` when switching to this deployment.