### PR TITLE
fix: configure github actions to inherit secrets

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -9,10 +9,4 @@ on:
 jobs:
   android_release:
     uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-android-release.yml@master
-    secrets:
-      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-      GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-      ALIAS: ${{ secrets.ALIAS }}
-      KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
-      KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+    secrets: inherit

--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -20,7 +20,4 @@ jobs:
     with:
       pr-title: ${{ inputs.pr-title }}
       pr-body: ${{ inputs.pr-body }}
-    secrets:
-      GDRIVE_CREDENTIALS: ${{ secrets.GDRIVE_CREDENTIALS }}
-      GDRIVE_TOKEN: ${{ secrets.GDRIVE_TOKEN }}
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -11,5 +11,4 @@ on:
 jobs:
   web_preview:
     uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-deploy-web-preview.yml@master
-    secrets:
-      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+    secrets: inherit

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -10,5 +10,4 @@ on:
 jobs:
   pr_preview:
     uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-deploy-pr-preview.yml@master
-    secrets:
-      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+    secrets: inherit

--- a/.github/workflows/firebase-release.yml
+++ b/.github/workflows/firebase-release.yml
@@ -11,5 +11,4 @@ jobs:
     uses: IDEMSInternational/open-app-builder/.github/workflows/reusable-deploy-web-preview.yml@master
     with: 
       firebase-host: ${{vars.FIREBASE_HOSTING_TARGET_RELEASE}} 
-    secrets:
-      FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+    secrets: inherit


### PR DESCRIPTION
Configures all github actions triggered from this repo to inherit the repo's secrets (in line with pattern on [debug repo](https://github.com/IDEMSInternational/app-debug-content/tree/main/.github/workflows))