### PR TITLE
chore(ci): update additional workflows to pass deployment private key secret

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -16,3 +16,4 @@ jobs:
       ALIAS: ${{ secrets.ALIAS }}
       KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
       KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+      DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}

--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -24,3 +24,4 @@ jobs:
       GDRIVE_CREDENTIALS: ${{ secrets.GDRIVE_CREDENTIALS }}
       GDRIVE_TOKEN: ${{ secrets.GDRIVE_TOKEN }}
       PAT: ${{ secrets.PAT }}
+      DEPLOYMENT_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_PRIVATE_KEY }}


### PR DESCRIPTION
Follow-up to #142. Updates workflows that target the reusable workflows updated in https://github.com/IDEMSInternational/open-app-builder/pull/2724