### PR TITLE
chore: bump content version to 1.3.2

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,7 +4,7 @@ const config = extendDeploymentConfig({ name: "plh_kids_kw", parent: "plh_kids" 
 
 config.git = {
   content_repo: "https://github.com/ParentingForLifelongHealth/plh-kids-app-kw-content",
-  content_tag_latest: "1.3.1",
+  content_tag_latest: "1.3.2",
 };
 
 config.android = {


### PR DESCRIPTION
Bumps content version number to 1.3.2 for new iOS release. No other changes.